### PR TITLE
Add slope physics skeleton to rust rewrite

### DIFF
--- a/src/Mirror/Voxel Games/prismals_game_rust/Cargo.toml
+++ b/src/Mirror/Voxel Games/prismals_game_rust/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 [dependencies]
 winit = "0.28"
 vulkano = { version = "0.33", default-features = false, features = ["macros", "vulkan10"] }
+nalgebra = "0.32"
 
 [workspace]


### PR DESCRIPTION
## Summary
- add nalgebra dependency
- implement basic InputState and Player structs
- simulate simple slope physics and handle input

## Testing
- `cargo check` *(fails: failed to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68572ee34ba8832ab5536d368484ebab